### PR TITLE
fixed typo in README.md file.

### DIFF
--- a/module-4/README.md
+++ b/module-4/README.md
@@ -71,7 +71,7 @@ We will use [mongoose](http://npmjs.org/packages/mongoose) as our Object Data Ma
 First we need to install mongoose:
 
 ```bash
-nom install mongoose --save
+npm install mongoose --save
 ```
 
 Navigate to the [Start](./Start) directory and create a new folder called **models** and then a new file called **models.js**:


### PR DESCRIPTION
It should be `npm install mongoose --save` instead of `nom install mongoose --save`.

See attached screen shot.

![screen shot 2015-05-18 at 5 12 30 pm](https://cloud.githubusercontent.com/assets/7308807/7693138/b311fc10-fd81-11e4-8cc7-964ea1cf4b5c.png)
