### PR TITLE
Return value in passport-init serializeUser

### DIFF
--- a/module-3/Finished/passport-init.js
+++ b/module-3/Finished/passport-init.js
@@ -9,7 +9,7 @@ module.exports = function(passport){
 	passport.serializeUser(function(user, done) {
 		console.log('serializing user:',user.username);
 		//return the unique id for the user
-		done(null, user.username);
+		return done(null, user.username);
 	});
 
 	//Desieralize user will call with the unique id provided by serializeuser

--- a/module-3/README.md
+++ b/module-3/README.md
@@ -548,7 +548,7 @@ Finally the serialize and deserialize handlers need to be provided a unique ID f
 passport.serializeUser(function(user, done) {
 	console.log('serializing user:',user.username);
 	//return the unique id for the user
-	done(null, user.username);
+	return done(null, user.username);
 });
 
 //Desieralize user will call with the unique id provided by serializeuser
@@ -573,7 +573,7 @@ module.exports = function(passport){
 	passport.serializeUser(function(user, done) {
 		console.log('serializing user:',user.username);
 		//return the unique id for the user
-		done(null, user.username);
+		return done(null, user.username);
 	});
 
 	//Desieralize user will call with the unique id provided by serializeuser


### PR DESCRIPTION
The `serializeUser` method in `passport-init.js` wasn't having any return value. 

It should return `done(null, user.username);`

It won't be a big change but `passport` module expects a return value from this function.
