### PR TITLE
fixed error in redirecting to register page

### DIFF
--- a/module-5/completed/public/index.html
+++ b/module-5/completed/public/index.html
@@ -14,7 +14,7 @@
 				<div class="container">
 					<a class="navbar-brand" href="#"> Chirp! </a>
 					<p class="navbar-text"> Learn the MEAN stack by building this tiny app</p>
-					<p class="navbar-right navbar-text" ng-hide="authenticated"><a href="#/login">Login</a> or <a href="#/signup">Register</a></p>
+					<p class="navbar-right navbar-text" ng-hide="authenticated"><a href="#/login">Login</a> or <a href="#/register">Register</a></p>
 					<p class="navbar-right navbar-text" ng-show="authenticated"><a href="#" ng-click="signout()">Logout</a></p>
 					<p class="navbar-right navbar-text" ng-show="authenticated">Signed in as {{current_user}}</p>
 				</div>


### PR DESCRIPTION
The link for the signup page was directed to `#/signup`, which doesn't exist. Changed the name to `#/register` which is the name of the register page HTML file.